### PR TITLE
[Changelog CI] Add Changelog for Version v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 * [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
 
 
+# Version: v1.0.0
+
+* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
+* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
+
+
 ## Mochi v1.0.1
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version: v1.0.0
+
+* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
+* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
+
+
 ## Mochi v1.0.1
 
 ### New


### PR DESCRIPTION
# Version: v1.0.0

* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
