### PR TITLE
[Changelog CI] Add Changelog for Version v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 * [#6](https://github.com/vixshan/Mochi/pull/6): Bump mongoose from 6.12.1 to 7.6.3
 
 
+# Version: v1.0.0
+
+* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
+* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
+* [#4](https://github.com/vixshan/Mochi/pull/4): Bump node-fetch from 2.7.0 to 3.3.2
+* [#5](https://github.com/vixshan/Mochi/pull/5): Bump parse-ms from 2.1.0 to 3.0.0
+* [#6](https://github.com/vixshan/Mochi/pull/6): Bump mongoose from 6.12.1 to 7.6.3
+
+
 ## Mochi v1.0.2
 
 ### Developer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Version: v1.0.0
+
+* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
+* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
+* [#4](https://github.com/vixshan/Mochi/pull/4): Bump node-fetch from 2.7.0 to 3.3.2
+* [#5](https://github.com/vixshan/Mochi/pull/5): Bump parse-ms from 2.1.0 to 3.0.0
+* [#6](https://github.com/vixshan/Mochi/pull/6): Bump mongoose from 6.12.1 to 7.6.3
+
+
 ## Mochi v1.0.2
 
 ### Developer


### PR DESCRIPTION
# Version: v1.0.0

* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
* [#4](https://github.com/vixshan/Mochi/pull/4): Bump node-fetch from 2.7.0 to 3.3.2
* [#5](https://github.com/vixshan/Mochi/pull/5): Bump parse-ms from 2.1.0 to 3.0.0
* [#6](https://github.com/vixshan/Mochi/pull/6): Bump mongoose from 6.12.1 to 7.6.3
