### PR TITLE
[Changelog CI] Add Changelog for Version v1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,3 +6,14 @@ Version: v1.0.2
 * `#4 <https://github.com/vixshan/Mochi/pull/4>`__: Bump node-fetch from 2.7.0 to 3.3.2
 * `#5 <https://github.com/vixshan/Mochi/pull/5>`__: Bump parse-ms from 2.1.0 to 3.0.0
 * `#6 <https://github.com/vixshan/Mochi/pull/6>`__: Bump mongoose from 6.12.1 to 7.6.3
+* `#15 <https://github.com/vixshan/Mochi/pull/15>`__: [Changelog CI] Add Changelog for Version v1.0.0
+
+
+Version: v1.0.2
+===============
+
+* `#2 <https://github.com/vixshan/Mochi/pull/2>`__: Bump jsdom from 21.1.2 to 22.1.0
+* `#3 <https://github.com/vixshan/Mochi/pull/3>`__: Bump chalk from 4.1.2 to 5.3.0
+* `#4 <https://github.com/vixshan/Mochi/pull/4>`__: Bump node-fetch from 2.7.0 to 3.3.2
+* `#5 <https://github.com/vixshan/Mochi/pull/5>`__: Bump parse-ms from 2.1.0 to 3.0.0
+* `#6 <https://github.com/vixshan/Mochi/pull/6>`__: Bump mongoose from 6.12.1 to 7.6.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,3 +17,14 @@ Version: v1.0.2
 * `#4 <https://github.com/vixshan/Mochi/pull/4>`__: Bump node-fetch from 2.7.0 to 3.3.2
 * `#5 <https://github.com/vixshan/Mochi/pull/5>`__: Bump parse-ms from 2.1.0 to 3.0.0
 * `#6 <https://github.com/vixshan/Mochi/pull/6>`__: Bump mongoose from 6.12.1 to 7.6.3
+* `#15 <https://github.com/vixshan/Mochi/pull/15>`__: [Changelog CI] Add Changelog for Version v1.0.0
+
+
+Version: v1.0.2
+===============
+
+* `#2 <https://github.com/vixshan/Mochi/pull/2>`__: Bump jsdom from 21.1.2 to 22.1.0
+* `#3 <https://github.com/vixshan/Mochi/pull/3>`__: Bump chalk from 4.1.2 to 5.3.0
+* `#4 <https://github.com/vixshan/Mochi/pull/4>`__: Bump node-fetch from 2.7.0 to 3.3.2
+* `#5 <https://github.com/vixshan/Mochi/pull/5>`__: Bump parse-ms from 2.1.0 to 3.0.0
+* `#6 <https://github.com/vixshan/Mochi/pull/6>`__: Bump mongoose from 6.12.1 to 7.6.3


### PR DESCRIPTION
# Version: v1.0.2

* [#2](https://github.com/vixshan/Mochi/pull/2): Bump jsdom from 21.1.2 to 22.1.0
* [#3](https://github.com/vixshan/Mochi/pull/3): Bump chalk from 4.1.2 to 5.3.0
* [#4](https://github.com/vixshan/Mochi/pull/4): Bump node-fetch from 2.7.0 to 3.3.2
* [#5](https://github.com/vixshan/Mochi/pull/5): Bump parse-ms from 2.1.0 to 3.0.0
* [#6](https://github.com/vixshan/Mochi/pull/6): Bump mongoose from 6.12.1 to 7.6.3
* [#15](https://github.com/vixshan/Mochi/pull/15): [Changelog CI] Add Changelog for Version v1.0.0
